### PR TITLE
bump ethpandaops/contributoor to v0.0.54

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "contributoor.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v0.0.53",
+  "upstreamVersion": "v0.0.54",
   "upstreamRepo": "ethpandaops/contributoor",
   "architectures": ["linux/amd64", "linux/arm64"],
   "license": "GPL-3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: sentry
       args:
-        UPSTREAM_VERSION: v0.0.53
+        UPSTREAM_VERSION: v0.0.54
     restart: unless-stopped
     environment:
       - CONTRIBUTOOR_USERNAME

--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -4,10 +4,7 @@
   "type": "service",
   "globalEnvs": [
     {
-      "envs": [
-        "CONSENSUS_CLIENT_HOLESKY",
-        "EXECUTION_CLIENT_HOLESKY"
-      ],
+      "envs": ["CONSENSUS_CLIENT_HOLESKY", "EXECUTION_CLIENT_HOLESKY"],
       "services": ["sentry"]
     }
   ]

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -4,10 +4,7 @@
   "type": "service",
   "globalEnvs": [
     {
-      "envs": [
-        "CONSENSUS_CLIENT_MAINNET",
-        "EXECUTION_CLIENT_MAINNET"
-      ],
+      "envs": ["CONSENSUS_CLIENT_MAINNET", "EXECUTION_CLIENT_MAINNET"],
       "services": ["sentry"]
     }
   ]


### PR DESCRIPTION
Bumps upstream version

- [ethpandaops/contributoor](https://github.com/ethpandaops/contributoor) from v0.0.53 to [v0.0.54](https://github.com/ethpandaops/contributoor/releases/tag/v0.0.54)