### PR TITLE
bump ethpandaops/contributoor to v0.0.55

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "contributoor.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v0.0.54",
+  "upstreamVersion": "v0.0.55",
   "upstreamRepo": "ethpandaops/contributoor",
   "architectures": ["linux/amd64", "linux/arm64"],
   "license": "GPL-3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: sentry
       args:
-        UPSTREAM_VERSION: v0.0.54
+        UPSTREAM_VERSION: v0.0.55
     restart: unless-stopped
     environment:
       - CONTRIBUTOOR_USERNAME


### PR DESCRIPTION
Bumps upstream version

- [ethpandaops/contributoor](https://github.com/ethpandaops/contributoor) from v0.0.54 to [v0.0.55](https://github.com/ethpandaops/contributoor/releases/tag/v0.0.55)