### PR TITLE
bump ethpandaops/contributoor to v0.0.59

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "contributoor.public.dappnode.eth",
   "version": "0.1.1",
-  "upstreamVersion": "v0.0.57",
+  "upstreamVersion": "v0.0.59",
   "upstreamRepo": "ethpandaops/contributoor",
   "architectures": ["linux/amd64", "linux/arm64"],
   "license": "GPL-3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: sentry
       args:
-        UPSTREAM_VERSION: v0.0.57
+        UPSTREAM_VERSION: v0.0.59
     restart: unless-stopped
     environment:
       - CONTRIBUTOOR_USERNAME


### PR DESCRIPTION
Bumps upstream version

- [ethpandaops/contributoor](https://github.com/ethpandaops/contributoor) from v0.0.57 to [v0.0.59](https://github.com/ethpandaops/contributoor/releases/tag/v0.0.59)