### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -11,7 +11,7 @@ jobs:
   bump-upstream:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - run: npx @dappnode/dappnodesdk github-action bump-upstream --use-variants --skip_build
 
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build test
     if: github.event_name != 'push'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - run: npx @dappnode/dappnodesdk build --skip_save
 
   release:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Publish
         run: npx @dappnode/dappnodesdk publish patch --provider remote --timeout 1h --all-variants --github-release
         env:


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.