### PR TITLE
feat: add support for hoodi network

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Contributoor is a monitoring and data-gathering tool that runs alongside your be
     - Find the Contributoor package of your desired network variant. 
         - [Install for Mainnet](http://my.dappnode/installer/public/contributoor-mainnet.public.dappnode.eth) 
         - [Install for Holesky](http://my.dappnode/installer/public/contributoor-holesky.public.dappnode.eth)
+        - [Install for Hoodi](http://my.dappnode/installer/public/contributoor-hoodi.public.dappnode.eth)
     - Click 'Install'. As part of the installation process, you will be asked to provide your credentials, these would have been provided to you by ethPandaOps.
 3. Once installed, the Contributoor package should appear in your installed packages list.
 4. The package will automatically detect your consensus client and configure itself appropriately.
@@ -41,7 +42,7 @@ You can get your IPFS address via the Dappnode Admin UI (Packages > System Packa
 There you will find your container IP, with the IPFS port being 5001 by default.
 
 ```bash
-dappnodesdk build --provider=IPFS_ADDRESS:5001 --variant=[mainnet|holesky]
+dappnodesdk build --provider=IPFS_ADDRESS:5001 --variant=[mainnet|holesky|hoodi]
 ```
 
 If you want to build/test for all variants, you can replace `--variant` with `--all-variants`.

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "contributoor.public.dappnode.eth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "upstreamVersion": "v0.0.62",
   "upstreamRepo": "ethpandaops/contributoor",
   "architectures": ["linux/amd64", "linux/arm64"],
@@ -25,7 +25,9 @@
         "CONSENSUS_CLIENT_MAINNET",
         "EXECUTION_CLIENT_MAINNET",
         "CONSENSUS_CLIENT_HOLESKY",
-        "EXECUTION_CLIENT_HOLESKY"
+        "EXECUTION_CLIENT_HOLESKY",
+        "CONSENSUS_CLIENT_HOODI",
+        "EXECUTION_CLIENT_HOODI"
       ],
       "services": ["sentry"]
     }

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "contributoor.public.dappnode.eth",
   "version": "0.1.2",
-  "upstreamVersion": "v0.0.62",
+  "upstreamVersion": "v0.0.63",
   "upstreamRepo": "ethpandaops/contributoor",
   "architectures": ["linux/amd64", "linux/arm64"],
   "license": "GPL-3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: sentry
       args:
-        UPSTREAM_VERSION: v0.0.62
+        UPSTREAM_VERSION: v0.0.63
     restart: unless-stopped
     environment:
       - CONTRIBUTOOR_USERNAME

--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "contributoor-holesky.public.dappnode.eth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "service",
   "globalEnvs": [
     {

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,0 +1,11 @@
+{
+  "name": "contributoor-hoodi.public.dappnode.eth",
+  "version": "0.1.2",
+  "type": "service",
+  "globalEnvs": [
+    {
+      "envs": ["CONSENSUS_CLIENT_HOODI", "EXECUTION_CLIENT_HOODI"],
+      "services": ["sentry"]
+    }
+  ]
+}

--- a/package_variants/hoodi/docker-compose.yml
+++ b/package_variants/hoodi/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "3.5"
+services:
+  sentry:
+    restart: unless-stopped

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "contributoor-mainnet.public.dappnode.eth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "service",
   "globalEnvs": [
     {

--- a/sentry/contributoor-start.sh
+++ b/sentry/contributoor-start.sh
@@ -12,6 +12,8 @@ if [ -n "$_DAPPNODE_GLOBAL_EXECUTION_CLIENT_MAINNET" ] || [ -n "$_DAPPNODE_GLOBA
     export NETWORK="mainnet"
 elif [ -n "$_DAPPNODE_GLOBAL_EXECUTION_CLIENT_HOLESKY" ] || [ -n "$_DAPPNODE_GLOBAL_CONSENSUS_CLIENT_HOLESKY" ]; then
     export NETWORK="holesky"
+elif [ -n "$_DAPPNODE_GLOBAL_EXECUTION_CLIENT_HOODI" ] || [ -n "$_DAPPNODE_GLOBAL_CONSENSUS_CLIENT_HOODI" ]; then
+    export NETWORK="hoodi"
 else
     echo "${ERROR} Could not determine NETWORK from DAppNode global variables"
     exit 1
@@ -66,6 +68,29 @@ case "$NETWORK" in
                 ;;
             *)
                 echo "${ERROR} Unknown or unsupported holesky consensus client: ${CONSENSUS_CLIENT}"
+                exit 1
+                ;;
+        esac
+        ;;
+    "hoodi")
+        case "$CONSENSUS_CLIENT" in
+            "prysm-hoodi.dnp.dappnode.eth")
+                BEACON_NODE_ADDR="http://beacon-chain.prysm-hoodi.dappnode:3500"
+                ;;
+            "teku-hoodi.dnp.dappnode.eth")
+                BEACON_NODE_ADDR="http://beacon-chain.teku-hoodi.dappnode:3500"
+                ;;
+            "lighthouse-hoodi.dnp.dappnode.eth")
+                BEACON_NODE_ADDR="http://beacon-chain.lighthouse-holesky.dappnode:3500"
+                ;;
+            "nimbus-hoodi.dnp.dappnode.eth")
+                BEACON_NODE_ADDR="http://beacon-validator.nimbus-hoodi.dappnode:4500"
+                ;;
+            "lodestar-hoodi.dnp.dappnode.eth")
+                BEACON_NODE_ADDR="http://beacon-chain.lodestar-hoodi.dappnode:3500"
+                ;;
+            *)
+                echo "${ERROR} Unknown or unsupported hoodi consensus client: ${CONSENSUS_CLIENT}"
                 exit 1
                 ;;
         esac

--- a/sentry/contributoor-start.sh
+++ b/sentry/contributoor-start.sh
@@ -38,7 +38,7 @@ case "$NETWORK" in
                 BEACON_NODE_ADDR="http://beacon-chain.lighthouse.dappnode:3500"
                 ;;
             "nimbus.dnp.dappnode.eth")
-                BEACON_NODE_ADDR="http://beacon-validator.nimbus.dappnode:4500"
+                BEACON_NODE_ADDR="http://beacon-chain.nimbus.dappnode:3500"
                 ;;
             "lodestar.dnp.dappnode.eth")
                 BEACON_NODE_ADDR="http://beacon-chain.lodestar.dappnode:3500"
@@ -61,7 +61,7 @@ case "$NETWORK" in
                 BEACON_NODE_ADDR="http://beacon-chain.lighthouse-holesky.dappnode:3500"
                 ;;
             "nimbus-holesky.dnp.dappnode.eth")
-                BEACON_NODE_ADDR="http://beacon-validator.nimbus-holesky.dappnode:4500"
+                BEACON_NODE_ADDR="http://beacon-chain.nimbus-holesky.dappnode:3500"
                 ;;
             "lodestar-holesky.dnp.dappnode.eth")
                 BEACON_NODE_ADDR="http://beacon-chain.lodestar-holesky.dappnode:3500"
@@ -81,10 +81,10 @@ case "$NETWORK" in
                 BEACON_NODE_ADDR="http://beacon-chain.teku-hoodi.dappnode:3500"
                 ;;
             "lighthouse-hoodi.dnp.dappnode.eth")
-                BEACON_NODE_ADDR="http://beacon-chain.lighthouse-holesky.dappnode:3500"
+                BEACON_NODE_ADDR="http://beacon-chain.lighthouse-hoodi.dappnode:3500"
                 ;;
             "nimbus-hoodi.dnp.dappnode.eth")
-                BEACON_NODE_ADDR="http://beacon-validator.nimbus-hoodi.dappnode:4500"
+                BEACON_NODE_ADDR="http://beacon-chain.nimbus-hoodi.dappnode:3500"
                 ;;
             "lodestar-hoodi.dnp.dappnode.eth")
                 BEACON_NODE_ADDR="http://beacon-chain.lodestar-hoodi.dappnode:3500"


### PR DESCRIPTION
This commit adds support for the Hoodi network to the Contributoor dappnode package. This includes:

- Adding a new package variant for Hoodi.
- Updating the README with instructions for installing the Hoodi package.
- Updating the dappnode_package.json file to include the Hoodi network.
- Updating the sentry/contributoor-start.sh script to support the Hoodi network.
- Updating package versions.

The Hoodi network is a test network for Ethereum. By adding support for Hoodi, Contributoor can be used to monitor and gather data from the Hoodi network.