### PR TITLE
bump ethpandaops/contributoor to v0.0.65

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "contributoor.public.dappnode.eth",
   "version": "0.1.2",
-  "upstreamVersion": "v0.0.64",
+  "upstreamVersion": "v0.0.65",
   "upstreamRepo": "ethpandaops/contributoor",
   "architectures": ["linux/amd64", "linux/arm64"],
   "license": "GPL-3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: sentry
       args:
-        UPSTREAM_VERSION: v0.0.64
+        UPSTREAM_VERSION: v0.0.65
     restart: unless-stopped
     environment:
       - CONTRIBUTOOR_USERNAME

--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "contributoor-holesky.public.dappnode.eth",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "service",
   "globalEnvs": [
     {

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "contributoor-hoodi.public.dappnode.eth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "service",
   "globalEnvs": [
     {

--- a/package_variants/mainnet/dappnode_package.json
+++ b/package_variants/mainnet/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "contributoor-mainnet.public.dappnode.eth",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "service",
   "globalEnvs": [
     {


### PR DESCRIPTION
Bumps upstream version

- [ethpandaops/contributoor](https://github.com/ethpandaops/contributoor) from v0.0.64 to [v0.0.65](https://github.com/ethpandaops/contributoor/releases/tag/v0.0.65)